### PR TITLE
Fix docker attach bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ https://e-class.ionio.gr/courses/NOC122/
 Κατεβάστε τα αρχεία `Dockerfile` και `setup.sh` σε ένα φάκελό σας (πχ με `git clone https://github.com/riggas-ionio/ml-lab.git` εντός αυτού του φακέλου).  
 Εκτελέστε (<ins>στο φάκελο που βρίσκονται τα `Dockerfile` και `setup.sh`</ins>):
 * `docker build -t ionio-ml-lab-image .` ώστε να δημιουργήσετε ένα image, όπως περιγράφει το Dockerfile
-* `docker run --name ionio-ml-lab -d -it ionio-ml-lab-image:latest` ώστε να ξεκινήσετε ένα container βασισμένο στο image που μόλις δημιουργήσατε.
-* `docker attach ionio-ml-lab` ώστε να _μπείτε_ στον container που μόλις ξεκινήσατε.
+* `docker run --name ionio-ml-lab -it ionio-ml-lab-image:latest` ώστε να ξεκινήσετε και να _μπείτε_ στο container βασισμένο στο image που μόλις δημιουργήσατε.
 
 Εντός του container θα πρέπει ήδη να είναι λειτουργικά το asciinema και το clips :-)


### PR DESCRIPTION
# Bug

Στο σημερινό μάθημα 19/02, υπήρχε ένα μικρό bug όταν τρέχαμε την εντολή ```docker attach ionio-ml-lab```. To bug ήταν ότι δεν μπορούσαμε να μπούμε στο container αν δεν πατούσαμε το enter. Το πρόβλημα είναι το flag ```-d``` το οποίο υπάρχει στην εντολή  ```docker run --name ionio-ml-lab -d -it ionio-ml-lab-image:latest```. Αν το αφαιρέσουμε, με το που τρέξουμε το container θα μπούμε αμέσως μετά μέσα σε αυτό και δεν θα χρειάζεται καθόλου η εντολή ```docker attach ionio-ml-lab```.